### PR TITLE
Prebuild support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,18 @@ sudo: false
 node_js:
   - 8
 
-compiler: clang-3.6
+os:
+  - linux
 
-env:
-  - CXX=clang-3.6
+matrix:
+  include:
+    - os: osx
+      env: COMPILER=clang++
+      osx_image: xcode9.2
+      compiler: clang
+    - os: linux
+      env: CXX=clang-3.6
+      compiler: clang-3.6
 
 addons:
   apt:
@@ -17,3 +25,16 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - clang-3.6
+
+branches:
+  only:
+    - master
+    - /^v.*$/
+
+deploy:
+  provider: script
+  script: npm run prebuild && npm run prebuild:upload -u ${PREBUILD_UPLOAD}
+  skip_cleanup: true
+  on:
+    all_branches: true
+    tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
 platform:
   - x64
+  - x86
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -20,3 +21,6 @@ build: off
 branches:
   only:
     - master
+    - /^v.*$/
+
+deploy_script: IF "%APPVEYOR_REPO_TAG%" == "true" (npm run prebuild && npm run prebuild:upload -u %PREBUILD_UPLOAD%)

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples.sh",
     "test-windows": "tree-sitter test"
-  }
+  },
+  "repository": "https://github.com/tree-sitter/tree-sitter-bash"
 }

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
+    "prebuild": "^7.6.1",
     "tree-sitter-cli": "^0.13.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",
+    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples.sh",
     "test-windows": "tree-sitter test"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Max Brunsfeld",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.10.0",
+    "prebuild-install": "^5.0.0"
   },
   "devDependencies": {
     "prebuild": "^7.6.1",
@@ -18,6 +19,7 @@
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",
+    "install": "prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --strip --verbose",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples.sh",


### PR DESCRIPTION
Adds prebuild and prebuild-install support.

`.travis.yml` was missing a branches filter. The AppVeyor config had it so I assumed it was just missing and added it.

`package.json` was missing a repository key. That's required for prebuild to correctly upload so I added that as well.

Helps resolve mads-hartmann/bash-language-server#62