### PR TITLE
Development experience

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ branches:
 
 deploy:
   provider: script
-  script: npm run prebuild && npm run prebuild:upload -u ${PREBUILD_UPLOAD}
+  script: npm run pre-build && npm run pre-build:upload -u ${PREBUILD_UPLOAD}
   skip_cleanup: true
   on:
     all_branches: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ tree-sitter-bash
 
 Bash grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
+### Development
+
+Install the dependencies:
+
+  npm install
+
+Build and run the tests:
+
+  npm run build
+  npm run test
+
+Run the build and tests in watch mode:
+
+  npm run test:watch
+
 #### References
 
 * [Bash man page](http://man7.org/linux/man-pages/man1/bash.1.html#SHELL_GRAMMAR)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,4 @@ branches:
     - master
     - /^v.*$/
 
-deploy_script: IF "%APPVEYOR_REPO_TAG%" == "true" (npm run prebuild && npm run prebuild:upload -u %PREBUILD_UPLOAD%)
+deploy_script: IF "%APPVEYOR_REPO_TAG%" == "true" (npm run pre-build && npm run pre-build:upload -u %PREBUILD_UPLOAD%)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prebuild-install": "^5.0.0"
   },
   "devDependencies": {
+    "nodemon": "^1.18.3",
     "prebuild": "^7.6.1",
     "tree-sitter-cli": "^0.13.1"
   },
@@ -23,7 +24,14 @@
     "pre-build": "prebuild --all --strip --verbose",
     "pre-build:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples.sh",
+    "test:watch": "nodemon --exec 'npm run build && npm run test' --ext js,txt,sh",
     "test-windows": "tree-sitter test"
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "build/",
+      "src/"
+    ]
   },
   "repository": "https://github.com/tree-sitter/tree-sitter-bash"
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild --all --strip --verbose",
-    "prebuild:upload": "prebuild --upload-all",
+    "pre-build": "prebuild --all --strip --verbose",
+    "pre-build:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples.sh",
     "test-windows": "tree-sitter test"
   },


### PR DESCRIPTION
This PR tries to improve the development experience by:
- adds a `test:watch` target which rebuilds and tests after making a change in the source files, corpus or examples (nice for TDD)
- adds some documentation on how to develop 
- renames the `prebuild` target to `pre-build` so running `npm run build` is much faster*

*) https://github.com/tree-sitter/tree-sitter-bash/pull/20 introduced a `prebuild` target, that has the consequence that local build and test cycle is really slow. The reason is that we are using the name `prebuild` for the target, which is always run before the `build` target.
