### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Install the dependencies:
 
 Build and run the tests:
 
-    npm run build
+    npx tree-sitter generate
     npm run test
 
 Run the build and tests in watch mode:
 
-    npm run test:watch
+    npx nodemon --exec 'npx tree-sitter generate && npm run test' --ext js,txt,sh
 
 #### References
 


### PR DESCRIPTION
It seems the README got a bit of sync since I updated it back in https://github.com/tree-sitter/tree-sitter-bash/pull/25 ... :) The `build` command and `test:watch` was removed in https://github.com/tree-sitter/tree-sitter-bash/commit/2a3aec56355982c7550443cd71c0fb830699d084

I suggest using npx instead if we didn't like the custom commands in the package.json.