### PR TITLE
adding zsh expansion flags

### DIFF
--- a/corpus/zsh.txt
+++ b/corpus/zsh.txt
@@ -1,0 +1,35 @@
+# See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion-Flags
+=============================
+Parameter Expansion Flags
+=============================
+echo ${(v)V}
+echo ${(s.:.)V}
+echo ${(@)V}
+echo ${()V}
+
+---
+
+(program
+  (command (command_name (word)) (expansion (expansion_flags) (variable_name)))
+  (command (command_name (word)) (expansion (expansion_flags) (variable_name)))
+  (command (command_name (word)) (expansion (expansion_flags) (variable_name)))
+  (command (command_name (word)) (expansion (expansion_flags) (variable_name))))
+
+=============================
+Parameter Expansion Flags Quotes
+=============================
+echo "${(v_sldkfj_sdklfj)V}"
+
+---
+
+(program
+  (command (command_name (word)) (string (expansion (expansion_flags) (variable_name)))))
+=============================
+Parameter Expansion Invalid Flags
+=============================
+echo "${(())V}"
+
+---
+
+(program
+(command (command_name (word)) (string (expansion (ERROR) (expansion_flags) (ERROR (word))))))

--- a/grammar.js
+++ b/grammar.js
@@ -490,8 +490,12 @@ module.exports = grammar({
 
     string_expansion: $ => seq('$', choice($.string, $.raw_string)),
 
+    // See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion-Flags
+    expansion_flags: ($) => seq("(", repeat(/[^()]/), ")"),
+
     expansion: $ => seq(
       '${',
+      optional($.expansion_flags),
       optional(choice('#', '!')),
       optional(choice(
         seq(

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
       "scope": "source.bash",
       "file-types": [
         "sh",
-        "bash"
+        "bash",
+        "zsh"
       ]
     }
   ]

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -46,6 +46,7 @@
   ">>"
   "<"
   "|"
+  (expansion_flags)
 ] @operator
 
 (

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2153,12 +2153,44 @@
         }
       ]
     },
+    "expansion_flags": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "PATTERN",
+            "value": "[^()]"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
     "expansion": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
           "value": "${"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "expansion_flags"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -639,6 +639,10 @@
           "named": true
         },
         {
+          "type": "expansion_flags",
+          "named": true
+        },
+        {
           "type": "regex",
           "named": true
         },
@@ -656,6 +660,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "expansion_flags",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "file_redirect",


### PR DESCRIPTION
See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion-Flags for more information on this

Hi all,

I'm wanting to add this feature that I understand is ZSH specific. I understand that this may not be desirable to have in the bash tree-sitter, but I figured I'd start the conversation with these changes and see what people's thoughts are.

I've added `zsh` to the package.json's `file-types` section. This can, likely, be removed and a user can add a `used_by` section to the config.

I've tested this with nvim and `tree-sitter highlight`(along with test, of course).