### PR TITLE
Allow `var=;` as valid syntax

### DIFF
--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -470,6 +470,28 @@ function do_yet_another_thing {
     (file_redirect (file_descriptor) (word))))
 
 =========================================
+Variable assignment: simple command
+=========================================
+
+var1=
+var2=something
+var3= var33= set
+var4=; var44=; set
+
+---
+
+(program
+  (variable_assignment (variable_name))
+  (variable_assignment (variable_name) (word))
+  (command
+    (variable_assignment (variable_name))
+    (variable_assignment (variable_name))
+    (command_name (word)))
+  (variable_assignment (variable_name))
+  (variable_assignment (variable_name))
+  (command (command_name (word))))
+
+=========================================
 Variable declaration: declare & typeset
 =========================================
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -191,7 +191,7 @@ struct Scanner {
     }
 
     if (valid_symbols[EMPTY_VALUE]) {
-      if (iswspace(lexer->lookahead)) {
+      if (iswspace(lexer->lookahead) || lexer->lookahead == ';') {
         lexer->result_symbol = EMPTY_VALUE;
         return true;
       }


### PR DESCRIPTION
The `;` marks the end of a simple command and hence it is not that uncommon to use it to separate variable assignments too:
```sh
loop=; variables=; here=;
while [ ... ]
  do ...
done
```

This adds the `;` as a valid character (along with whitespaces).
As an aside, technically the following characters can be used the same way: `|`, `&`, `<`, `>` (but I don't know who would...).
