### PR TITLE
fix: # in concat position

### DIFF
--- a/corpus/programs.txt
+++ b/corpus/programs.txt
@@ -5,11 +5,49 @@ Comments
 #!/bin/bash
 # hi
 
+echo 'word'#not-comment
+echo $(uname -a)#not-comment
+echo `uname -a`#not-comment
+echo $hey####not-comment
+
 ---
 
 (program
   (comment)
-  (comment))
+  (comment)
+  (command
+    (command_name
+      (word))
+    (concatenation
+      (raw_string)
+      (word)))
+  (command
+    (command_name
+      (word))
+    (concatenation
+      (command_substitution
+        (command
+          (command_name
+            (word))
+          (word)))
+      (word)))
+  (command
+    (command_name
+      (word))
+    (concatenation
+      (command_substitution
+        (command
+          (command_name
+            (word))
+          (word)))
+      (word)))
+  (command
+    (command_name
+      (word))
+    (concatenation
+      (simple_expansion
+        (variable_name))
+      (word))))
 
 ===============================
 Escaped newlines

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1351,7 +1351,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_concat"
+              "name": "_any_concat"
             },
             {
               "type": "BLANK"
@@ -1367,7 +1367,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_concat"
+              "name": "_any_concat"
             },
             {
               "type": "BLANK"
@@ -1894,22 +1894,31 @@
               "type": "PREC",
               "value": -1,
               "content": {
-                "type": "SEQ",
+                "type": "CHOICE",
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_concat"
+                    "name": "_concat_oct"
                   },
                   {
-                    "type": "CHOICE",
+                    "type": "SEQ",
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "_primary_expression"
+                        "name": "_concat"
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "_special_character"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_primary_expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_special_character"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -2024,7 +2033,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_concat"
+                    "name": "_any_concat"
                   },
                   {
                     "type": "BLANK"
@@ -2049,6 +2058,19 @@
         {
           "type": "STRING",
           "value": "\""
+        }
+      ]
+    },
+    "_any_concat": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_concat"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_concat_oct"
         }
       ]
     },
@@ -2651,6 +2673,10 @@
     },
     {
       "type": "SYMBOL",
+      "name": "_concat_oct"
+    },
+    {
+      "type": "SYMBOL",
       "name": "variable_name"
     },
     {
@@ -2679,6 +2705,7 @@
     }
   ],
   "inline": [
+    "_any_concat",
     "_statement",
     "_terminator",
     "_literal",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -15,6 +15,7 @@ enum TokenType {
   FILE_DESCRIPTOR,
   EMPTY_VALUE,
   CONCAT,
+  CONCAT_OCT,
   VARIABLE_NAME,
   REGEX,
   CLOSING_BRACE,
@@ -181,10 +182,21 @@ struct Scanner {
         lexer->lookahead == '&' ||
         lexer->lookahead == '|' ||
         lexer->lookahead == '`' ||
-        lexer->lookahead == '#' ||
         (lexer->lookahead == '}' && valid_symbols[CLOSING_BRACE]) ||
         (lexer->lookahead == ']' && valid_symbols[CLOSING_BRACKET])
       )) {
+        if (lexer->lookahead == '#') {
+            while (lexer->lookahead == '#') {
+                lexer->advance(lexer, false);
+            }
+
+            if (iswspace(lexer->lookahead) || !iswalnum(lexer->lookahead)) {
+                lexer->result_symbol = CONCAT_OCT;
+                return true;
+            }
+        }
+        
+
         lexer->result_symbol = CONCAT;
         return true;
       }


### PR DESCRIPTION
Should fix https://github.com/tree-sitter/tree-sitter-bash/issues/127

Edit: Except the following example
```
var=#something
```

It would be nicer to fix it without adding CONCAT_OCT but during testing the parser always got stuck at CONCAT.