### PR TITLE
Fix scanning of heredoc_body to allow empty bodies

### DIFF
--- a/corpus/commands.txt
+++ b/corpus/commands.txt
@@ -265,3 +265,58 @@ usage() {
         (command (command_name (word)))
         (heredoc_redirect (heredoc_start)))
       (heredoc_body (expansion (special_variable_name) (word))))))
+
+==========================================
+Heredocs with empty bodies
+==========================================
+
+node <<JS
+JS
+
+node << 'SJ'
+SJ
+
+usage() {
+	cat <<-EOF
+	EOF
+}
+
+node << 'EOF' > temp
+EOF
+
+---
+
+(program
+ (redirected_statement
+  body: (command
+         name: (command_name
+                (word)))
+  redirect: (heredoc_redirect
+             (heredoc_start)))
+ (heredoc_body)
+ (redirected_statement
+  body: (command
+         name: (command_name
+                (word)))
+  redirect: (heredoc_redirect
+             (heredoc_start)))
+ (heredoc_body)
+ (function_definition
+  name: (word)
+  body: (compound_statement
+         (redirected_statement
+          body: (command
+                 name: (command_name
+                        (word)))
+          redirect: (heredoc_redirect
+                     (heredoc_start)))
+         (heredoc_body)))
+ (redirected_statement
+  body: (command
+         name: (command_name
+                (word)))
+  redirect: (heredoc_redirect
+             (heredoc_start))
+  redirect: (file_redirect
+             destination: (word)))
+ (heredoc_body))

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -89,9 +89,11 @@ struct Scanner {
   bool scan_heredoc_end_identifier(TSLexer *lexer) {
     current_leading_word.clear();
     // Scan the first 'n' characters on this line, to see if they match the heredoc delimiter
+    int32_t i = 0;
     while (
       lexer->lookahead != '\0' &&
       lexer->lookahead != '\n' &&
+      ((int32_t)heredoc_delimiter[i++]) == lexer->lookahead &&
       current_leading_word.length() < heredoc_delimiter.length()
     ) {
       current_leading_word += lexer->lookahead;
@@ -159,6 +161,14 @@ struct Scanner {
         }
 
         default: {
+          if (scan_heredoc_end_identifier(lexer)) {
+            heredoc_is_raw = false;
+            started_heredoc = false;
+            heredoc_allows_indent = false;
+            heredoc_delimiter.clear();
+            lexer->result_symbol = end_type;
+            return true;
+          }
           did_advance = true;
           advance(lexer);
           break;


### PR DESCRIPTION
Empty heredoc_body such as the example bellow was being miss parsed:

```bash
echo <<EOF
EOF
echo "Hello"
```

In the example above EOF\necho "Hello" was captured as heredoc_body. 

This PR fixes the scanning of heredoc_body to allow for heredocs with empty bodies to be correctly parsed.