### PR TITLE
[fix] Here-documents: parse a “real” shell word (or close enough) after `<<`

### DIFF
--- a/corpus/commands.txt
+++ b/corpus/commands.txt
@@ -337,9 +337,19 @@ node <<!HEREDOC!
 Hello.
 !HEREDOC!
 
+node <<\'
+Hello.
+'
+
+node <<\\
+Hello.
+\
+
 ---
 
 (program
+  (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
+  (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
   (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
   (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
   (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body))

--- a/corpus/commands.txt
+++ b/corpus/commands.txt
@@ -320,3 +320,26 @@ EOF
   redirect: (file_redirect
              destination: (word)))
  (heredoc_body))
+
+==========================================
+Heredocs with weird characters
+==========================================
+
+node <<_DELIMITER_WITH_UNDERSCORES_
+Hello.
+_DELIMITER_WITH_UNDERSCORES_
+
+node <<'```'
+Hello.
+```
+
+node <<!HEREDOC!
+Hello.
+!HEREDOC!
+
+---
+
+(program
+  (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
+  (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body)
+  (redirected_statement (command (command_name (word))) (heredoc_redirect (heredoc_start))) (heredoc_body))

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -367,10 +367,12 @@ struct Scanner {
 
     while (lexer->lookahead && ! (quote ? lexer->lookahead == quote :
                                   iswspace(lexer->lookahead))) {
-      if (lexer->lookahead != '\\') {
-        empty = false;
-        unquoted_word += lexer->lookahead;
+      if (lexer->lookahead == '\\') {
+        advance(lexer);
+        if (! lexer->lookahead) return false;
       }
+      empty = false;
+      unquoted_word += lexer->lookahead;
       advance(lexer);
     }
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -359,19 +359,18 @@ struct Scanner {
   bool advance_word(TSLexer *lexer, string& unquoted_word) {
     bool empty = true;
 
-    if (lexer->lookahead == '\\') {
-      advance(lexer);
-    }
-
     int32_t quote = 0;
     if (lexer->lookahead == '\'' || lexer->lookahead == '"') {
       quote = lexer->lookahead;
       advance(lexer);
     }
 
-    while (iswalpha(lexer->lookahead) || (quote != 0 && iswspace(lexer->lookahead))) {
-      unquoted_word += lexer->lookahead;
-      empty = false;
+    while (lexer->lookahead && ! (quote ? lexer->lookahead == quote :
+                                  iswspace(lexer->lookahead))) {
+      if (lexer->lookahead != '\\') {
+        empty = false;
+        unquoted_word += lexer->lookahead;
+      }
       advance(lexer);
     }
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -63,7 +63,12 @@ struct Scanner {
     heredoc_is_raw = lexer->lookahead == '\'';
     started_heredoc = false;
     heredoc_delimiter.clear();
-    return advance_word(lexer, heredoc_delimiter);
+
+    string delimiter;
+    bool found_delimiter = advance_word(lexer, delimiter);
+    if (found_delimiter) heredoc_delimiter.assign(delimiter);
+
+    return found_delimiter;
   }
 
   bool scan_heredoc_end_identifier(TSLexer *lexer) {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -63,27 +63,7 @@ struct Scanner {
     heredoc_is_raw = lexer->lookahead == '\'';
     started_heredoc = false;
     heredoc_delimiter.clear();
-
-    if (lexer->lookahead == '\\') {
-      advance(lexer);
-    }
-
-    int32_t quote = 0;
-    if (heredoc_is_raw || lexer->lookahead == '"') {
-      quote = lexer->lookahead;
-      advance(lexer);
-    }
-
-    while (iswalpha(lexer->lookahead) || (quote != 0 && iswspace(lexer->lookahead))) {
-      heredoc_delimiter += lexer->lookahead;
-      advance(lexer);
-    }
-
-    if (lexer->lookahead == quote) {
-      advance(lexer);
-    }
-
-    return !heredoc_delimiter.empty();
+    return advance_word(lexer, heredoc_delimiter);
   }
 
   bool scan_heredoc_end_identifier(TSLexer *lexer) {
@@ -367,6 +347,39 @@ struct Scanner {
     }
 
     return false;
+  }
+
+  /**
+   * Consume a "word" in POSIX parlance, and returns it unquoted.
+   *
+   * This is an approximate implementation that doesn't deal with any
+   * POSIX-mandated substitution, and assumes the default value for
+   * IFS.
+   */
+  bool advance_word(TSLexer *lexer, string& unquoted_word) {
+    bool empty = true;
+
+    if (lexer->lookahead == '\\') {
+      advance(lexer);
+    }
+
+    int32_t quote = 0;
+    if (lexer->lookahead == '\'' || lexer->lookahead == '"') {
+      quote = lexer->lookahead;
+      advance(lexer);
+    }
+
+    while (iswalpha(lexer->lookahead) || (quote != 0 && iswspace(lexer->lookahead))) {
+      unquoted_word += lexer->lookahead;
+      empty = false;
+      advance(lexer);
+    }
+
+    if (quote && lexer->lookahead == quote) {
+      advance(lexer);
+    }
+
+    return ! empty;
   }
 
   string heredoc_delimiter;


### PR DESCRIPTION
Fixes #58, #88 and #129.
