### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -28,6 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
Using `submodules` for `actions/checkout@v3` requires setting `fetch-depth: 0` as well, for whatever reason.

https://github.com/actions/checkout/issues/176#issuecomment-597131018