### PR TITLE
fix: heredocs with many trailing file redirects

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -433,7 +433,7 @@ module.exports = grammar({
     file_redirect: $ => prec.left(seq(
       field('descriptor', optional($.file_descriptor)),
       choice('<', '>', '>>', '&>', '&>>', '<&', '>&', '>|'),
-      field('destination', repeat1($._literal)),
+      field('destination', $._literal),
     )),
 
     heredoc_redirect: $ => seq(
@@ -441,7 +441,7 @@ module.exports = grammar({
       choice('<<', '<<-'),
       $.heredoc_start,
       optional(seq(
-        choice(alias($._heredoc_pipeline, $.pipeline), $.file_redirect),
+        choice(alias($._heredoc_pipeline, $.pipeline), repeat1($.file_redirect)),
       )),
       '\n',
       choice($._heredoc_body, $._simple_heredoc_body),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2038,11 +2038,8 @@
             "type": "FIELD",
             "name": "destination",
             "content": {
-              "type": "REPEAT1",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_literal"
-              }
+              "type": "SYMBOL",
+              "name": "_literal"
             }
           }
         ]
@@ -2103,8 +2100,11 @@
                       "value": "pipeline"
                     },
                     {
-                      "type": "SYMBOL",
-                      "name": "file_redirect"
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "file_redirect"
+                      }
                     }
                   ]
                 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1183,7 +1183,7 @@
         ]
       },
       "destination": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {

--- a/test/corpus/commands.txt
+++ b/test/corpus/commands.txt
@@ -239,6 +239,34 @@ wc -l $tmpfile
       (variable_name))))
 
 =================================
+Heredocs with many file redirects
+=================================
+
+FOO=bar echo <<EOF 2> err.txt > hello.txt
+hello
+EOF
+
+---
+
+(program
+  (redirected_statement
+    (command
+      (variable_assignment
+        (variable_name)
+        (word))
+      (command_name
+        (word)))
+    (heredoc_redirect
+      (heredoc_start)
+      (file_redirect
+        (file_descriptor)
+        (word))
+      (file_redirect
+        (word))
+      (simple_heredoc_body)
+      (heredoc_end))))
+
+=================================
 Heredocs with pipes
 =================================
 


### PR DESCRIPTION
Before:

![Screenshot from 2023-08-24 15-59-56](https://github.com/tree-sitter/tree-sitter-bash/assets/14666676/faa57e1f-4bd3-4944-b943-51bf8c76ffca)

After:

![Screenshot from 2023-08-24 16-16-39](https://github.com/tree-sitter/tree-sitter-bash/assets/14666676/566b3f01-167b-4530-adca-40e189a3781e)
