### PR TITLE
fix: don't expose `\n` rule anchors as visible anonymous nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -71,7 +71,7 @@ module.exports = grammar({
     ']',
     '<<',
     '<<-',
-    '\n',
+    /\n/,
   ],
 
   extras: $ => [
@@ -443,7 +443,7 @@ module.exports = grammar({
       optional(seq(
         choice(alias($._heredoc_pipeline, $.pipeline), repeat1($.file_redirect)),
       )),
-      '\n',
+      /\n/,
       choice($._heredoc_body, $._simple_heredoc_body),
     ),
 
@@ -823,7 +823,7 @@ module.exports = grammar({
         $.arithmetic_expansion,
         $.expansion,
         $.parenthesized_expression,
-        '\n',
+        /\n/,
       ),
       optional(seq(
         field('operator', ':'),
@@ -831,7 +831,7 @@ module.exports = grammar({
           $._simple_variable_name,
           $.number,
           $.arithmetic_expansion,
-          '\n',
+          /\n/,
         )),
       )),
     ),
@@ -912,8 +912,8 @@ module.exports = grammar({
 
     test_operator: _ => token(prec(1, seq('-', /[a-zA-Z]+/))),
 
-    _c_terminator: _ => choice(';', '\n', '&'),
-    _terminator: _ => choice(';', ';;', '\n', '&'),
+    _c_terminator: _ => choice(';', /\n/, '&'),
+    _terminator: _ => choice(';', ';;', /\n/, '&'),
   },
 });
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2116,8 +2116,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\n"
         },
         {
           "type": "CHOICE",
@@ -4378,8 +4378,8 @@
               "name": "parenthesized_expression"
             },
             {
-              "type": "STRING",
-              "value": "\n"
+              "type": "PATTERN",
+              "value": "\\n"
             }
           ]
         },
@@ -4416,8 +4416,8 @@
                           "name": "arithmetic_expansion"
                         },
                         {
-                          "type": "STRING",
-                          "value": "\n"
+                          "type": "PATTERN",
+                          "value": "\\n"
                         }
                       ]
                     },
@@ -4967,8 +4967,8 @@
           "value": ";"
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\n"
         },
         {
           "type": "STRING",
@@ -4988,8 +4988,8 @@
           "value": ";;"
         },
         {
-          "type": "STRING",
-          "value": "\n"
+          "type": "PATTERN",
+          "value": "\\n"
         },
         {
           "type": "STRING",
@@ -5132,8 +5132,8 @@
       "value": "<<-"
     },
     {
-      "type": "STRING",
-      "value": "\n"
+      "type": "PATTERN",
+      "value": "\\n"
     }
   ],
   "inline": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1390,10 +1390,6 @@
         "required": true,
         "types": [
           {
-            "type": "\n",
-            "named": false
-          },
-          {
             "type": "&",
             "named": false
           },
@@ -2206,10 +2202,6 @@
         "required": true,
         "types": [
           {
-            "type": "\n",
-            "named": false
-          },
-          {
             "type": "&",
             "named": false
           },
@@ -2297,10 +2289,6 @@
     "type": "word",
     "named": true,
     "fields": {}
-  },
-  {
-    "type": "\n",
-    "named": false
   },
   {
     "type": "!",


### PR DESCRIPTION
Should be merged after: #197