### PR TITLE
Restore missing fields in variable assignments in C-style for loops

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -191,9 +191,9 @@ module.exports = grammar({
     ),
 
     _c_variable_assignment: $ => seq(
-      alias($._c_word, $.variable_name),
+      field('name', alias($._c_word, $.variable_name)),
       '=',
-      $._c_expression,
+      field('value', $._c_expression),
     ),
     _c_unary_expression: $ => prec.left(seq(
       field('operator', choice('++', '--')),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -550,21 +550,29 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
+          "type": "FIELD",
+          "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "_c_word"
-          },
-          "named": true,
-          "value": "variable_name"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_c_word"
+            },
+            "named": true,
+            "value": "variable_name"
+          }
         },
         {
           "type": "STRING",
           "value": "="
         },
         {
-          "type": "SYMBOL",
-          "name": "_c_expression"
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_c_expression"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2023,7 +2023,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "subscript",
@@ -2037,7 +2037,7 @@
       },
       "value": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
           {
             "type": "_primary_expression",
@@ -2048,65 +2048,31 @@
             "named": true
           },
           {
+            "type": "binary_expression",
+            "named": true
+          },
+          {
             "type": "concatenation",
+            "named": true
+          },
+          {
+            "type": "parenthesized_expression",
+            "named": true
+          },
+          {
+            "type": "postfix_expression",
+            "named": true
+          },
+          {
+            "type": "unary_expression",
+            "named": true
+          },
+          {
+            "type": "variable_assignment",
             "named": true
           }
         ]
       }
-    },
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "binary_expression",
-          "named": true
-        },
-        {
-          "type": "command_substitution",
-          "named": true
-        },
-        {
-          "type": "expansion",
-          "named": true
-        },
-        {
-          "type": "number",
-          "named": true
-        },
-        {
-          "type": "parenthesized_expression",
-          "named": true
-        },
-        {
-          "type": "postfix_expression",
-          "named": true
-        },
-        {
-          "type": "simple_expansion",
-          "named": true
-        },
-        {
-          "type": "string",
-          "named": true
-        },
-        {
-          "type": "unary_expression",
-          "named": true
-        },
-        {
-          "type": "variable_assignment",
-          "named": true
-        },
-        {
-          "type": "variable_name",
-          "named": true
-        },
-        {
-          "type": "word",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -452,7 +452,6 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
             lexer->lookahead == '?' || lexer->lookahead == '-' ||
             lexer->lookahead == '0' || lexer->lookahead == '_') {
             lexer->mark_end(lexer);
-            bool was_dollar = lexer->lookahead == '$';
             advance(lexer);
             if (lexer->lookahead == '=' || lexer->lookahead == '[' ||
                 lexer->lookahead == ':' || lexer->lookahead == '-' ||
@@ -544,15 +543,16 @@ static bool scan(Scanner *scanner, TSLexer *lexer, const bool *valid_symbols) {
         return false;
     }
 
-    if (valid_symbols[REGEX] || valid_symbols[REGEX_NO_SLASH] ||
-        valid_symbols[REGEX_NO_SPACE] && !in_error_recovery(valid_symbols)) {
+    if ((valid_symbols[REGEX] || valid_symbols[REGEX_NO_SLASH] ||
+         valid_symbols[REGEX_NO_SPACE]) &&
+        !in_error_recovery(valid_symbols)) {
         if (valid_symbols[REGEX] || valid_symbols[REGEX_NO_SPACE]) {
             while (iswspace(lexer->lookahead)) {
                 skip(lexer);
             }
         }
 
-        if (lexer->lookahead != '"' && lexer->lookahead != '\'' ||
+        if ((lexer->lookahead != '"' && lexer->lookahead != '\'') ||
             (lexer->lookahead == '$' && valid_symbols[REGEX_NO_SLASH])) {
             typedef struct {
                 bool done;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,8 +1,9 @@
 #include <assert.h>
 #include <ctype.h>
 #include <string.h>
-#include <tree_sitter/parser.h>
 #include <wctype.h>
+
+#include "tree_sitter/parser.h"
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 


### PR DESCRIPTION
Closes #204 

@thesamesam do you guys use tree-sitter-bash on master or latest release? If the latter, I'll see about fixing comments in command substitutions before creating another release

and note this is generated on master to hopefully avoid the bugs described in #199, since parser.h is included as a local file