### PR TITLE
Add `first-line-regex` and `injection-regex` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,16 @@
   "tree-sitter": [
     {
       "scope": "source.bash",
+      "injection-regex": "(shell|bash|zsh|sh)",
+      "first-line-regex": "^#!.*\\b(sh|bash|dash|zsh)\\b.*$",
       "file-types": [
         "sh",
-        "bash"
+        "bash",
+        "zsh",
+        ".bashrc",
+        ".bash_profile",
+        ".zshrc",
+        "zshrc"
       ]
     }
   ]


### PR DESCRIPTION
This allows using the grammar for injections within the tree-sitter CLI, and detecting files that have shebangs but not names.

Also expand the `file-types` array.