### PR TITLE
separate out `'` inside raw string

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -841,7 +841,12 @@ module.exports = grammar({
       ')',
     ),
 
-    raw_string: _ => /'[^']*'/,
+    raw_string_content: _ => token(prec(-1, /([^']|\\')*/)),
+    raw_string: $ => seq(
+      '\'',
+      $.raw_string_content,
+      '\'',
+    ),
 
     ansi_c_string: _ => /\$'([^']|\\')*'/,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5213,9 +5213,33 @@
         }
       ]
     },
+    "raw_string_content": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "PATTERN",
+          "value": "([^']|\\\\')*"
+        }
+      }
+    },
     "raw_string": {
-      "type": "PATTERN",
-      "value": "'[^']*'"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "raw_string_content"
+        },
+        {
+          "type": "STRING",
+          "value": "'"
+        }
+      ]
     },
     "ansi_c_string": {
       "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1737,6 +1737,21 @@
     }
   },
   {
+    "type": "raw_string",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "raw_string_content",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "redirected_statement",
     "named": true,
     "fields": {
@@ -2335,6 +2350,10 @@
     "named": false
   },
   {
+    "type": "'",
+    "named": false
+  },
+  {
     "type": "(",
     "named": false
   },
@@ -2711,7 +2730,7 @@
     "named": false
   },
   {
-    "type": "raw_string",
+    "type": "raw_string_content",
     "named": true
   },
   {

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
This PR splits up the `raw_string` node in the grammar so that the single quotes are separate (literal) nodes in the tree, like they are with double quotes in strings.

This is done so that editors like [Zed](https://zed.dev) (where I am an employee) can identify the opening and closing quotes of a `raw_string` as part of standard bracket queries.

In addition to the aformentioned change, I also modified the regex that defines the contents of a `raw_string` to include escaped single quotes `\'` so that escaped quotes are not interpreted as the end of the `raw_string`

I am relatively new to contributing changes to tree-sitter grammars, so apologies in advance if I've missed a generated artifact I should've committed.
