### PR TITLE
build: add windows mingw-w64 compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,18 +13,17 @@
         "src/parser.c",
         "src/scanner.c",
       ],
-      "conditions": [
-        ["OS!='win'", {
-          "cflags_c": [
-            "-std=c11",
-          ],
-        }, { # OS == "win"
-          "cflags_c": [
+      "cflags_c": [
+        "-std=c11",
+      ],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
             "/std:c11",
             "/utf-8",
           ],
-        }],
-      ],
+        },
+      },
     }
   ]
 }

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from os import path
-from platform import system
 from sysconfig import get_config_var
+from distutils.ccompiler import new_compiler
 
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build
@@ -21,10 +21,10 @@ macros: list[tuple[str, str | None]] = [
 if limited_api := not get_config_var("Py_GIL_DISABLED"):
     macros.append(("Py_LIMITED_API", "0x030A0000"))
 
-if system() != "Windows":
-    cflags = ["-std=c11", "-fvisibility=hidden"]
-else:
+if new_compiler().compiler_type == "msvc":
     cflags = ["/std:c11", "/utf-8"]
+else:
+    cflags = ["-std=c11", "-fvisibility=hidden"]
 
 
 class Build(build):


### PR DESCRIPTION
Now the build config only supports MSVC on Windows, but it will fail with mingw-w64's gcc and clang in MSys2, etc.

This PR tries to enable it to be built with mingw-w64's gcc and clang.